### PR TITLE
player1とplayer2の表示画像の修正

### DIFF
--- a/app/src/main/java/kouta/numberon/Model/Mode.kt
+++ b/app/src/main/java/kouta/numberon/Model/Mode.kt
@@ -1,6 +1,5 @@
 package kouta.numberon.Model
 
-import kouta.numberon.Model.gameInfo
 
 interface Mode {
     fun setMode(mode : String) {

--- a/app/src/main/java/kouta/numberon/Model/gameInfo.kt
+++ b/app/src/main/java/kouta/numberon/Model/gameInfo.kt
@@ -2,7 +2,7 @@ package kouta.numberon.Model
 
 class gameInfo {
     companion object {
-        lateinit var gameMode : String
+        var gameMode : String = ""
         var gameDigit = 0
         var firstPlayer = 1
     }

--- a/app/src/main/java/kouta/numberon/Presenter/activity/OrderContract.kt
+++ b/app/src/main/java/kouta/numberon/Presenter/activity/OrderContract.kt
@@ -13,6 +13,6 @@ interface OrderContract {
 
         fun getDigitRequestCode() : Int
         fun getPlayer1CardKey() : String
-        fun getplayer2CardKey() : String
+        fun getPlayer2CardKey() : String
     }
 }

--- a/app/src/main/java/kouta/numberon/Presenter/activity/OrderPresenter.kt
+++ b/app/src/main/java/kouta/numberon/Presenter/activity/OrderPresenter.kt
@@ -15,7 +15,7 @@ class OrderPresenter : OrderContract.Presenter {
         return DataUtils().PLAYER1_CARD
     }
 
-    override fun getplayer2CardKey() : String {
+    override fun getPlayer2CardKey() : String {
         return DataUtils().PLAYER2_CARD
     }
 }

--- a/app/src/main/java/kouta/numberon/Presenter/fragment/OrderResultContract.kt
+++ b/app/src/main/java/kouta/numberon/Presenter/fragment/OrderResultContract.kt
@@ -12,6 +12,6 @@ interface OrderResultContract {
 
     interface Presenter : BasePresenter, NumberToCard, FirstPlayer {
         fun getPlayer1CardKey() : String
-        fun getplayer2CardKey() : String
+        fun getPlayer2CardKey() : String
     }
 }

--- a/app/src/main/java/kouta/numberon/Presenter/fragment/OrderResultPresenter.kt
+++ b/app/src/main/java/kouta/numberon/Presenter/fragment/OrderResultPresenter.kt
@@ -11,7 +11,7 @@ class OrderResultPresenter : OrderResultContract.Presenter {
         return DataUtils().PLAYER1_CARD
     }
 
-    override fun getplayer2CardKey() : String {
+    override fun getPlayer2CardKey() : String {
         return DataUtils().PLAYER2_CARD
     }
 }

--- a/app/src/main/java/kouta/numberon/view/Fragment/OrderResultFragment.kt
+++ b/app/src/main/java/kouta/numberon/view/Fragment/OrderResultFragment.kt
@@ -31,7 +31,7 @@ class OrderResultFragment : Fragment(), OrderResultContract.View {
          */
         if (argument != null) {
             player1 = argument.getInt(presenter.getPlayer1CardKey())
-            player2 = argument.getInt(presenter.getPlayer1CardKey())
+            player2 = argument.getInt(presenter.getPlayer2CardKey())
         }
 
         val card1 = presenter.numberToCard(player1)

--- a/app/src/main/java/kouta/numberon/view/activity/OrderActivity.kt
+++ b/app/src/main/java/kouta/numberon/view/activity/OrderActivity.kt
@@ -83,7 +83,7 @@ class OrderActivity : AppCompatActivity(), View.OnClickListener, OrderContract.V
                         card_number = card_number.shuffled()
                         val bundle = Bundle()
                         bundle.putInt(presenter.getPlayer1CardKey(), card_number[player1])
-                        bundle.putInt(presenter.getPlayer1CardKey(), card_number[player2])
+                        bundle.putInt(presenter.getPlayer2CardKey(), card_number[player2])
 
                         val fragment = OrderResultFragment()
                         fragment.arguments = bundle


### PR DESCRIPTION
#29 の対応を行なった

どちらの数字が大きいかに関わらずどちらにもplayer1の画像が表示されていた。
なので、正常にそれぞれの画像が表示されるように変更した。